### PR TITLE
Compressor and Decopressor release should be handled by dispose and finalizer

### DIFF
--- a/LibDeflate.Bindings/LibDeflateBinding.cs
+++ b/LibDeflate.Bindings/LibDeflateBinding.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace System.IO.Compression;
@@ -30,14 +30,6 @@ public sealed class LibDeflateBinding : IDisposable
     {
         _compressor = NativeMethods.libdeflate_alloc_compressor((int)compressionLevel);
         _decompressor = NativeMethods.libdeflate_alloc_decompressor();
-
-        AppDomain.CurrentDomain.ProcessExit += CurrentDomain_ProcessExit;
-    }
-
-    private void CurrentDomain_ProcessExit(object? sender, EventArgs e)
-    {
-        NativeMethods.libdeflate_free_compressor(_compressor);
-        NativeMethods.libdeflate_free_decompressor(_decompressor);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -72,7 +64,8 @@ public sealed class LibDeflateBinding : IDisposable
 
     private void ReleaseUnmanagedResources()
     {
-        AppDomain.CurrentDomain.ProcessExit -= CurrentDomain_ProcessExit;
+        NativeMethods.libdeflate_free_compressor(_compressor);
+        NativeMethods.libdeflate_free_decompressor(_decompressor);
     }
 
     public void Dispose()


### PR DESCRIPTION
Compressor and Decopressor release should be handled by dispose and finalizer because they are unmanaged resources.

The use of "ProcessExit" event was in place from previous porting where compressor and decompressor were static variables and could not be released by dispose or finalizer